### PR TITLE
Update Component prop-types to allow a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ import 'react-autocomplete-input/dist/bundle.css';
 # Configurable Props
 *Note*: All props are optional.
 
-## Component : string
+## Component : string or func
 #### Default value: `"textarea"`
 Widget for rendering input field
 

--- a/src/AutoCompleteTextField.jsx
+++ b/src/AutoCompleteTextField.jsx
@@ -15,7 +15,10 @@ const OPTION_LIST_Y_OFFSET = 10;
 const OPTION_LIST_MIN_WIDTH = 100;
 
 const propTypes = {
-  Component: PropTypes.string,
+  Component: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+  ]),
   defaultValue: PropTypes.string,
   disabled: PropTypes.bool,
   maxOptions: PropTypes.number,


### PR DESCRIPTION
Suppress the prop-type warning when a function is given as mentioned in https://github.com/yury-dymov/react-autocomplete-input/issues/19