### PR TITLE
Handle uppercase options

### DIFF
--- a/src/AutoCompleteTextField.jsx
+++ b/src/AutoCompleteTextField.jsx
@@ -139,7 +139,7 @@ class AutocompleteTextField extends React.Component {
       if (matchStart >= 0) {
         const matchedSlug = str.substring(matchStart, caret);
         const options = providedOptions.filter((slug) => {
-          const idx = slug.indexOf(matchedSlug);
+          const idx = slug.toLowerCase().indexOf(matchedSlug);
           return idx !== -1 && (matchAny || idx === 0);
         });
 

--- a/test/AutoCompleteTextField.spec.js
+++ b/test/AutoCompleteTextField.spec.js
@@ -137,6 +137,19 @@ describe('option list filtering', () => {
     expect(component.find('.react-autocomplete-input > li')).to.have.length(2);
   });
 
+  it('ABC => 3 options', () => {
+    const component = mount(<TextField trigger="@" options={["aa", "ab", "abc", "abcd", "ABCDE"]} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@ABC'));
+    expect(component.find('.react-autocomplete-input > li')).to.have.length(3);
+  });
+
+  it('abc => 3 options including one uppercase', () => {
+    const component = mount(<TextField trigger="@" options={["aa", "ab", "abc", "abcd", "ABCDE"]} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@abc'));
+    expect(component.find('.react-autocomplete-input > li')).to.have.length(3);
+  });
 });
 
 describe('max options test', () => {


### PR DESCRIPTION
Currently the options dropdown won't match any options that use uppercase, e.g. if there is an option "TAG" it won't be matched by either typing "ta" or "TA". This PR fixes that.

## Before
'l' or 'L' does not match the option 'LOWER'
![before](https://user-images.githubusercontent.com/5218648/36652215-3afb9964-1b12-11e8-9034-b77356d24af2.gif)

## After
'T' matches 'tag' or 'TAG'
![after](https://user-images.githubusercontent.com/5218648/36652219-4005d28a-1b12-11e8-9ff5-c6d80b6a59d1.gif)
