### PR TITLE
Add min chars option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ By default, after option is selected, it is inserted with following space. If us
 #### Default value: `'@'`
 Character or string, which triggers showing autocompletion option list. '' and '@@' are both valid triggers. Keep in mind that user have to input at least one extra character to make option list available if empty trigger is used.
 
+## minChars: number
+#### Default value: 0
+Only show autocompletion option list after this many characters have been typed after the trigger character.
+
 ## value : string
 #### Default value: `''`
 Widget supports both controlling options: by value and by state. If you explicitly pass `value` prop, you have to update it manually every time `onChange` event is emitted. If you don't pass `value` prop, then widget uses internal state for value manipulation.

--- a/src/AutoCompleteTextField.jsx
+++ b/src/AutoCompleteTextField.jsx
@@ -29,6 +29,7 @@ const propTypes = {
   options: PropTypes.array,
   regex: PropTypes.string,
   matchAny: PropTypes.bool,
+  minChars: PropTypes.number,
   requestOnlyIfNoOptions: PropTypes.bool,
   spaceRemovers: PropTypes.array,
   trigger: PropTypes.string,
@@ -49,6 +50,7 @@ const defaultProps = {
   options: [],
   regex: '^[A-Za-z0-9\\-_]+$',
   matchAny: false,
+  minChars: 0,
   requestOnlyIfNoOptions: true,
   spaceRemovers: [',', '.', '!', '?'],
   trigger: '@',
@@ -298,7 +300,9 @@ class AutocompleteTextField extends React.Component {
         input.offsetLeft + rect.width - OPTION_LIST_MIN_WIDTH
       );
 
-      if (slug.options.length > 1 || (slug.options.length === 1 && slug.options[0].length !== slug.matchLength)) {
+      if (
+        slug.matchLength >= this.props.minChars &&
+        (slug.options.length > 1 || (slug.options.length === 1 && slug.options[0].length !== slug.matchLength))) {
         this.setState({ helperVisible: true, top, left, ...slug });
       } else {
         if (!this.props.requestOnlyIfNoOptions || !slug.options.length) {

--- a/test/AutoCompleteTextField.spec.js
+++ b/test/AutoCompleteTextField.spec.js
@@ -101,6 +101,24 @@ describe('option list is shown for different trigger strings', () => {
   });
 });
 
+describe('option list is only shown if matched string is longer than minChars', () => {
+  it('does not trigger with minChars 1 and @', () => {
+    const component = mount(<TextField trigger="@" minChars={1} options={["aa", "ab"]} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@'));
+
+    expect(component.find('.react-autocomplete-input')).to.have.length(0);
+  });
+
+  it('does trigger with minChars 1 and @a', () => {
+    const component = mount(<TextField trigger="@" minChars={1} options={["aa", "ab"]} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@a'));
+
+    expect(component.find('.react-autocomplete-input')).to.have.length(1);
+  });
+});
+
 describe('option list appearance', () => {
   it('hide if no options available', () => {
     const component = mount(<TextField trigger="@" options={["aa", "ab"]} />);


### PR DESCRIPTION
Adds an option to only show the autocomplete options list after a certain amount of characters have been typed. This is so we don't get a giant list of results when we first type the trigger.

![screen capture on 2018-02-26 at 17-22-28](https://user-images.githubusercontent.com/5218648/36653446-0f98a1e2-1b1a-11e8-89d5-856547e2b783.gif)
