### PR TITLE
Replace componentWillRecieveProps and findDOMNode

### DIFF
--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { createRef } from 'react';
 import PropTypes from 'prop-types';
-import { findDOMNode } from 'react-dom';
 import getCaretCoordinates from 'textarea-caret';
 import getInputSelection, { setCaretPosition } from 'get-input-selection';
 import './AutoCompleteTextField.css';
@@ -89,18 +88,19 @@ class AutocompleteTextField extends React.Component {
 
     this.recentValue = props.defaultValue;
     this.enableSpaceRemovers = false;
+    this.refInput = createRef();
   }
 
   componentDidMount() {
     window.addEventListener('resize', this.handleResize);
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     const { options } = this.props;
     const { caret } = this.state;
 
-    if (options.length !== nextProps.options.length) {
-      this.updateHelper(this.recentValue, caret, nextProps.options);
+    if (options.length !== prevProps.options.length) {
+      this.updateHelper(this.recentValue, caret, options);
     }
   }
 
@@ -213,7 +213,7 @@ class AutocompleteTextField extends React.Component {
             const newValue = (`${str.slice(0, i - 1)}${str.slice(i, i + 1)}${str.slice(i - 1, i)}${str.slice(i + 1)}`);
 
             this.updateCaretPosition(i + 1);
-            findDOMNode(this.refInput).value = newValue;
+            this.refInput.current.value = newValue;
 
             if (!value) {
               this.setState({ value: newValue });
@@ -283,7 +283,7 @@ class AutocompleteTextField extends React.Component {
     const part1 = value.substring(0, matchStart);
     const part2 = value.substring(matchStart + matchLength);
 
-    const event = { target: findDOMNode(this.refInput) };
+    const event = { target: this.refInput.current };
 
     event.target.value = `${part1}${slug}${spacer}${part2}`;
     this.handleChange(event);
@@ -296,11 +296,11 @@ class AutocompleteTextField extends React.Component {
   }
 
   updateCaretPosition(caret) {
-    this.setState({ caret }, () => setCaretPosition(findDOMNode(this.refInput), caret));
+    this.setState({ caret }, () => setCaretPosition(this.refInput.current, caret));
   }
 
   updateHelper(str, caret, options) {
-    const input = findDOMNode(this.refInput);
+    const input = this.refInput.current;
 
     const slug = this.getMatch(str, caret, options);
 
@@ -434,7 +434,7 @@ class AutocompleteTextField extends React.Component {
           onBlur={onBlur}
           onChange={this.handleChange}
           onKeyDown={this.handleKeyDown}
-          ref={(c) => { this.refInput = c; }}
+          ref={this.refInput}
           value={val}
           {...propagated}
         />

--- a/test/AutoCompleteTextField.spec.js
+++ b/test/AutoCompleteTextField.spec.js
@@ -592,6 +592,7 @@ describe('updating props', () => {
     expect(component.find('.react-autocomplete-input > li')).to.have.length(2);
 
     component.setProps({ options: ["aa", "ab", "ac"] });
+    component.update(); // needed because componentDidUpdate re-renders with updated values
 
     expect(component.find('.react-autocomplete-input > li')).to.have.length(3);
   });


### PR DESCRIPTION
- Remove deprecated `findDOMNode` and use a ref instead.
- Replace deprecated `componentWillRecieveProps` with `componentDidUpdate`. This did require a small test change because the old method did not trigger a intermediate render as the code ran earlier in the component lifecycle. Adding a `setTimeout(fn, 0)` is an alternative to `component.update()`.

Fixes: https://github.com/yury-dymov/react-autocomplete-input/issues/37