### PR TITLE
Use PropTypes.elementType to support wrapped components

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "get-input-selection": "^1.1.4",
-    "prop-types": "^15.6.2",
+    "prop-types": "^15.7.2",
     "textarea-caret": "^3.0.2"
   },
   "peerDependencies": {

--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -17,7 +17,7 @@ const OPTION_LIST_MIN_WIDTH = 100;
 const propTypes = {
   Component: PropTypes.oneOfType([
     PropTypes.string,
-    PropTypes.func,
+    PropTypes.elementType,
   ]),
   defaultValue: PropTypes.string,
   disabled: PropTypes.bool,


### PR DESCRIPTION
Components wrapped in `forwardRef`do not identify as a function but as a object. Use [`PropTypes.elementType`](https://github.com/facebook/prop-types/pull/211) to allow those as well.

Fixes: https://github.com/yury-dymov/react-autocomplete-input/issues/40