### PR TITLE
Add passThroughEnter prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ Only show autocompletion option list after this many characters have been typed 
 #### Default value: `''`
 Widget supports both controlling options: by value and by state. If you explicitly pass `value` prop, you have to update it manually every time `onChange` event is emitted. If you don't pass `value` prop, then widget uses internal state for value manipulation.
 
+## passThroughEnter: boolean
+#### Default value: false
+If true, then an enter / return keypress is passed on (after being used to autocomplete). 
+Useful if you want to have the form submit as soon as a single value is chosen. 
+
 # Styles Customization
 By default styles are defined in `"react-autocomplete-input/dist/bundle.css"`, however, you may define your custom styles instead for following entities:
 

--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -37,6 +37,7 @@ const propTypes = {
   value: PropTypes.string,
   offsetX: PropTypes.number,
   offsetY: PropTypes.number,
+  passThroughEnter: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -59,6 +60,7 @@ const defaultProps = {
   offsetX: 0,
   offsetY: 0,
   value: null,
+  passThroughEnter: false,
 };
 
 class AutocompleteTextField extends React.Component {
@@ -241,7 +243,7 @@ class AutocompleteTextField extends React.Component {
 
   handleKeyDown(event) {
     const { helperVisible, options, selection } = this.state;
-    const { onKeyDown } = this.props;
+    const { onKeyDown, passThroughEnter } = this.props;
 
     if (helperVisible) {
       switch (event.keyCode) {
@@ -259,8 +261,10 @@ class AutocompleteTextField extends React.Component {
           break;
         case KEY_ENTER:
         case KEY_RETURN:
+          if (!passThroughEnter) { event.preventDefault(); }
+          this.handleSelection(selection);
+          break;
         case KEY_TAB:
-          event.preventDefault();
           this.handleSelection(selection);
           break;
         default:


### PR DESCRIPTION
I needed a textbox that allows autocompletion of a single tag and then submits - ie one 'enter' keypress, not two. This seemed like the easiest way to do it.

Not sure if this feature is useful for others, so no worries at all if it's not merged.