### PR TITLE
Support for multiple triggers and custom options for each trigger

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,10 @@
     "react/no-find-dom-node": 0,
     "react/forbid-foreign-prop-types": 0,
     "jsx-a11y/click-events-have-key-events": 0,
-    "jsx-a11y/no-noninteractive-element-interactions": 0
+    "jsx-a11y/no-noninteractive-element-interactions": 0,
+    "class-methods-use-this": 0,
+    "brace-style": "off",
+    "arrow-parens": "off"
   },
   "globals": {
     "window": true

--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -469,7 +469,7 @@ class AutocompleteTextField extends React.Component {
     const { value: stateValue } = this.state;
 
     const propagated = Object.assign({}, rest);
-    Object.keys(this.constructor.propTypes).forEach((k) => { delete propagated[k]; });
+    Object.keys(propTypes).forEach((k) => { delete propagated[k]; });
 
     let val = '';
 

--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -152,7 +152,7 @@ class AutocompleteTextField extends React.Component {
           const triggerIdx = triggerMatch ? i : i - triggerLength + 1;
 
           if (triggerIdx < 0) { // out of input
-            return slugData;
+            continue
           }
 
           if (this.isTrigger(triggerStr, str, triggerIdx)) {
@@ -160,7 +160,7 @@ class AutocompleteTextField extends React.Component {
           }
 
           if (!match && matchStart < 0) {
-            return slugData;
+            continue
           }
         } else {
           if (match && i > 0) { // find first non-matching character or begin of input
@@ -169,7 +169,7 @@ class AutocompleteTextField extends React.Component {
           matchStart = i === 0 && match ? 0 : i + 1;
 
           if (caret - matchStart === 0) { // matched slug is empty
-            return slugData;
+            continue
           }
         }
 
@@ -469,7 +469,7 @@ class AutocompleteTextField extends React.Component {
     const { value: stateValue } = this.state;
 
     const propagated = Object.assign({}, rest);
-    Object.keys(this.constructor.propTypes).forEach((k) => { delete propagated[k]; });
+    Object.keys(propTypes).forEach((k) => { delete propagated[k]; });
 
     let val = '';
 

--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -152,7 +152,7 @@ class AutocompleteTextField extends React.Component {
           const triggerIdx = triggerMatch ? i : i - triggerLength + 1;
 
           if (triggerIdx < 0) { // out of input
-            continue
+            break;
           }
 
           if (this.isTrigger(triggerStr, str, triggerIdx)) {
@@ -160,7 +160,7 @@ class AutocompleteTextField extends React.Component {
           }
 
           if (!match && matchStart < 0) {
-            continue
+            break;
           }
         } else {
           if (match && i > 0) { // find first non-matching character or begin of input
@@ -169,7 +169,7 @@ class AutocompleteTextField extends React.Component {
           matchStart = i === 0 && match ? 0 : i + 1;
 
           if (caret - matchStart === 0) { // matched slug is empty
-            continue
+            break;
           }
         }
 
@@ -469,7 +469,7 @@ class AutocompleteTextField extends React.Component {
     const { value: stateValue } = this.state;
 
     const propagated = Object.assign({}, rest);
-    Object.keys(propTypes).forEach((k) => { delete propagated[k]; });
+    Object.keys(this.constructor.propTypes).forEach((k) => { delete propagated[k]; });
 
     let val = '';
 

--- a/test/AutoCompleteTextField.spec.js
+++ b/test/AutoCompleteTextField.spec.js
@@ -79,6 +79,38 @@ describe('option list is shown for different trigger strings', () => {
     expect(component.find('.react-autocomplete-input')).to.have.length(1);
   });
 
+  it('trigger [@]', () => {
+    const component = mount(<TextField trigger={["@"]} options={["aa", "ab"]} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@'));
+
+    expect(component.find('.react-autocomplete-input')).to.have.length(1);
+  });
+
+  it('trigger [@@]', () => {
+    const component = mount(<TextField trigger={["@@"]} options={["aa", "ab"]} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@'));
+
+    expect(component.find('.react-autocomplete-input')).to.have.length(0);
+  });
+
+  it('trigger [@, @@] 1/2', () => {
+    const component = mount(<TextField trigger={["@", "@@"]} options={["ar", "az"]} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@'));
+
+    expect(component.find('.react-autocomplete-input')).to.have.length(1);
+  });
+
+  it('trigger [@, @@] 2/2', () => {
+    const component = mount(<TextField trigger={["@", "@@"]} options={["aa", "ab"]} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@@'));
+
+    expect(component.find('.react-autocomplete-input')).to.have.length(1);
+  });
+
   it('trigger contains upper-case characters', () => {
     const component = mount(<TextField trigger="TRIGGER" options={["aa", "ab"]} />);
 
@@ -104,7 +136,15 @@ describe('option list is shown for different trigger strings', () => {
   });
 
   it('trigger empty, option list should appear if first letter matched', () => {
-    const component = mount(<TextField options={["aa", "ab"]} trigger="" />);
+    const component = mount(<TextField trigger="" options={["aa", "ab"]} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('a'));
+
+    expect(component.find('.react-autocomplete-input > li')).to.have.length(2);
+  });
+
+  it('trigger array of empty string, option list should appear if first letter matched', () => {
+    const component = mount(<TextField trigger={[""]} options={{"": ["aa", "ab"]}} />);
 
     component.find('textarea').simulate('change', createOnChangeEvent('a'));
 
@@ -121,8 +161,24 @@ describe('option list is only shown if matched string is longer than minChars', 
     expect(component.find('.react-autocomplete-input')).to.have.length(0);
   });
 
+  it('does not trigger with minChars 1 and @ with trigger [@]', () => {
+    const component = mount(<TextField trigger={["@"]} minChars={1} options={["aa", "ab"]} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@'));
+
+    expect(component.find('.react-autocomplete-input')).to.have.length(0);
+  });
+
   it('does trigger with minChars 1 and @a', () => {
     const component = mount(<TextField trigger="@" minChars={1} options={["aa", "ab"]} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@a'));
+
+    expect(component.find('.react-autocomplete-input')).to.have.length(1);
+  });
+
+  it('does trigger with minChars 1 and @a with trigger [@]', () => {
+    const component = mount(<TextField trigger={["@"]} minChars={1} options={{"@": ["aa", "ab"]}} />);
 
     component.find('textarea').simulate('change', createOnChangeEvent('@a'));
 
@@ -133,6 +189,16 @@ describe('option list is only shown if matched string is longer than minChars', 
 describe('option list appearance', () => {
   it('hide if no options available', () => {
     const component = mount(<TextField trigger="@" options={["aa", "ab"]} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@a'));
+    expect(component.find('.react-autocomplete-input')).to.have.length(1);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@ad'));
+    expect(component.find('.react-autocomplete-input')).to.have.length(0);
+  });
+
+  it('hide if no options available with trigger [@]', () => {
+    const component = mount(<TextField trigger={["@"]} options={["aa", "ab"]} />);
 
     component.find('textarea').simulate('change', createOnChangeEvent('@a'));
     expect(component.find('.react-autocomplete-input')).to.have.length(1);
@@ -179,6 +245,20 @@ describe('option list filtering', () => {
     component.find('textarea').simulate('change', createOnChangeEvent('@abc'));
     expect(component.find('.react-autocomplete-input > li')).to.have.length(3);
   });
+
+  it('abc => 3 options including one uppercase', () => {
+    const component = mount(<TextField trigger={["@"]} options={{"@":["aa", "ab", "abc", "abcd", "ABCDE"]}} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@abc'));
+    expect(component.find('.react-autocomplete-input > li')).to.have.length(3);
+  });
+
+  it('abc => 3 options including one uppercase', () => {
+    const component = mount(<TextField trigger={["@", "@@"]} options={{"@":["aa", "ab"], "@@":["abc", "abcd", "ABCDE"]}} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@@abc'));
+    expect(component.find('.react-autocomplete-input > li')).to.have.length(3);
+  });
 });
 
 describe('max options test', () => {
@@ -198,10 +278,26 @@ describe('max options test', () => {
     expect(component.find('.react-autocomplete-input > li')).to.have.length(3);
   });
 
+  it('options: 5, maxOptions: 3 => 3 options', () => {
+    const component = mount(<TextField trigger={["@", "@@"]} options={{"@": ["aa", "ab", "abc", "abcd", "abcde"], "@@":["ab, ac"]}} maxOptions={3} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@a'));
+
+    expect(component.find('.react-autocomplete-input > li')).to.have.length(3);
+  });
+
   it('options: 10, maxOptions: 0 => 10 options', () => {
     const component = mount(<TextField trigger="@" options={["aa", "ab", "abc", "abcd", "abcde", "ae", "af", "ag", "ah", "az"]} maxOptions={0} />);
 
     component.find('textarea').simulate('change', createOnChangeEvent('@a'));
+
+    expect(component.find('.react-autocomplete-input > li')).to.have.length(10);
+  });
+
+  it('options: 10, maxOptions: 0 => 10 options', () => {
+    const component = mount(<TextField trigger={["@", "@@"]} options={{"@@": ["aa", "ab", "abc", "abcd", "abcde", "ae", "af", "ag", "ah", "az"]}} maxOptions={0} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@@a'));
 
     expect(component.find('.react-autocomplete-input > li')).to.have.length(10);
   });


### PR DESCRIPTION
The main purpose behind this pull request is to allow users to have multiple triggers that have different options.

This is done by allowing the trigger prop to be either a string or array of strings (I kept it as string OR array of strings so already existent code passing trigger a string doesn't break).
`<TextField trigger={["@"]} options={["aa", "ab", "abc", "abcd"]} />`

The options prop can now be either an array or an object that maps each trigger to a specific option array (this was kept as an array OR object for the same reason). If the option prop is an array and the trigger prop is an array of strings then all triggers will have the same options.
`<TextField trigger={["@", "@@"]} options={{"@": ["aa", "ab", "abc", "abcd"], "@@": ["az", "ar"]}} />`
`<TextField trigger=["@", "@@"] options={["aa", "ab", "abc", "abcd"]} />` Here both triggers will have the same options

I also included tests for this feature to show that it's functional and how it would operate.

Changes made to the eslintrc were made to combat errors shown below:
Change - "arrow-parens": "off"
Reasoning - So I can return an object with an arrow function
`const triggersMatch = triggers.map((trigger) => ({
      triggerStr: trigger,
      triggerMatch: trigger.match(re),
      triggerLength: trigger.length,
    }));`

Change - "class-methods-use-this": 0
Reasoning - Without this method like `arrayTriggerMatch` and `isTrigger` would give an error because I didn't use `this` inside the method

Change - "brace-style": "off"
Reasoning - So I can have my `else if` on a different line instead of next to the closing bracket of my `if` block

Overall I hope this code is useful and can be merged if there aren't any errors :)