### PR TITLE
New changeOnSelect Prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Defines how many options can be listed simultaneously. Show all matched options 
 #### Default value: `() => {}`
 Callback invoked upon selecting an option. Receives selection value as a parameter.
 
+## changeOnSelect : func
+#### Default value: `(trigger, slug) => trigger + slug`
+Callback invoked upon selecting an option, will display what the function returns. Receives trigger and selection value as a parameter.
+
 ## onRequestOptions : func
 #### Default value: `() => {}`
 Callback for requesting new options to support lazy-loading. If `requestOnlyIfNoOptions` is true, then `onRequestOptions` called only if no options are currently available. Otherwise `onRequestOptions` is called every time text is changed and `trigger` is found.

--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -346,15 +346,15 @@ class AutocompleteTextField extends React.Component {
     const part2 = value.substring(matchStart + matchLength);
 
     const event = { target: this.refInput.current };
-    const selectedStr = changeOnSelect(trigger, slug);
+    const changedStr = changeOnSelect(trigger, slug);
 
-    event.target.value = `${part1}${selectedStr}${spacer}${part2}`;
+    event.target.value = `${part1}${changedStr}${spacer}${part2}`;
     this.handleChange(event);
     onSelect(event.target.value);
 
     this.resetHelper();
 
-    this.updateCaretPosition(part1.length + selectedStr.length + 1);
+    this.updateCaretPosition(part1.length + changedStr.length + 1);
 
     this.enableSpaceRemovers = true;
   }

--- a/test/AutoCompleteTextField.spec.js
+++ b/test/AutoCompleteTextField.spec.js
@@ -572,6 +572,48 @@ describe('selecting option from list', () => {
     expect(component.find('textarea')).to.have.html().match(/@aa/);
   });
 
+  it('enter with changeOnSelect, return slug => hide options, update textarea', () => {
+    const component = mount(<TextField options={["aa", "ab"]} changeOnSelect={(trigger, slug) => slug} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@'));
+    component.find('textarea').simulate('change', createOnChangeEvent('@a'));
+
+    expect(component.find('.react-autocomplete-input')).to.have.length(1);
+
+    component.find('textarea').simulate('keyDown', { keyCode: KEY_ENTER });
+
+    expect(component.find('.react-autocomplete-input')).to.have.length(0);
+    expect(component.find('textarea')).to.have.html().match(/aa/);
+  });
+
+  it('enter with changeOnSelect, return trigger => hide options, update textarea', () => {
+    const component = mount(<TextField options={["aa", "ab"]} changeOnSelect={(trigger, slug) => trigger} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@'));
+    component.find('textarea').simulate('change', createOnChangeEvent('@a'));
+
+    expect(component.find('.react-autocomplete-input')).to.have.length(1);
+
+    component.find('textarea').simulate('keyDown', { keyCode: KEY_ENTER });
+
+    expect(component.find('.react-autocomplete-input')).to.have.length(0);
+    expect(component.find('textarea')).to.have.html().match(/@/);
+  });
+
+  it('enter with changeOnSelect, return trigger+slug => hide options, update textarea', () => {
+    const component = mount(<TextField options={["aa", "ab"]} changeOnSelect={(trigger, slug) => trigger + slug} />);
+
+    component.find('textarea').simulate('change', createOnChangeEvent('@'));
+    component.find('textarea').simulate('change', createOnChangeEvent('@a'));
+
+    expect(component.find('.react-autocomplete-input')).to.have.length(1);
+
+    component.find('textarea').simulate('keyDown', { keyCode: KEY_ENTER });
+
+    expect(component.find('.react-autocomplete-input')).to.have.length(0);
+    expect(component.find('textarea')).to.have.html().match(/@aa/);
+  });
+
   it('tab => hide options, update textarea', () => {
     const component = mount(<TextField options={["aa", "ab"]} />);
 


### PR DESCRIPTION
Sometimes when selecting an option it might be useful to take the selected option and modify it a bit. A perfect example of this is how discord handles tagging users. Someone can tag another user using the @ character which might look like this, @Lazaro. Although this is what the user sees the true text is <@148912207109816321>. Allowing the user to select an easy-to-read option and then on selection converting it to a proper format is a great feature. Below I explain every change I made.

### changeOnSelect Prop
This new function prop is what handles modifying the selected text. It takes in the trigger and slug value and it uses its return value as the text to display.

### New trigger key in this.state
Since there could be multiple triggers it is useful to have which trigger the user used saved in the state.

### part1 variable
The part1 variable use to include the trigger but since the default changeOnSelect function returns the trigger and slug together it now excludes it. To exclude it we take the trigger from the state and make the end index equal to matchStart - trigger.length.

### event.target.value AND updateCaretPosition
Since the user might choose to modify the selected option both event.target.value AND updateCaretPosition are now taking the changedStr variable which is the return value of the changeOnSelect function.

### New tests
New tests were added to verify this feature is working properly for current and future builds. This is also a good example of how the prop operates.

I decided to create another prop instead of implementing this feature on the current existing onSelect prop to not break the existing code some people might have. I also added this prop to the README but if you think it is not descriptive enough please let me know or feel free to change it if this PR is accepted.
