### PR TITLE
Dont add first character when trigger is empty

### DIFF
--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -342,7 +342,7 @@ class AutocompleteTextField extends React.Component {
 
     const slug = options[idx];
     const value = this.recentValue;
-    const part1 = value.substring(0, matchStart - trigger.length);
+    const part1 = trigger.length === 0 ? "" : value.substring(0, matchStart - trigger.length);
     const part2 = value.substring(matchStart + matchLength);
 
     const event = { target: this.refInput.current };


### PR DESCRIPTION
Hi Yury,

Thank you for creating/ maintaining this library!

I found a bug where if the currentValue is set and you select a new value that the first character of the currentValue is added to the new value when trigger is set empty ("")

Can you take a look at my fix please?

Kind regards