### PR TITLE
 Fix single option autocompletion

### DIFF
--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -382,7 +382,7 @@ class AutocompleteTextField extends React.Component {
       if (
         slug.matchLength >= minChars
         && (
-          slug.options.length > 1
+          slug.options.length >= 1
           || (
             slug.options.length === 1
             && slug.options[0].length !== slug.matchLength

--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -382,10 +382,10 @@ class AutocompleteTextField extends React.Component {
       if (
         slug.matchLength >= minChars
         && (
-          slug.options.length >= 1
+          slug.options.length > 1
           || (
             slug.options.length === 1
-            && slug.options[0].length !== slug.matchLength
+            && (slug.options[0].length !== slug.matchLength || slug.options[0].length === 1)
           )
         )
       ) {


### PR DESCRIPTION
If there are any options with a single character, the autocomplete input field ignores that and does not show anything in the dropdown as choices. 

This PR fixes this by ensuring that options with at least one character is used.


Eg: `[z]` is the only option that is available. If you type `z` in the input, it does not show up in the autocomplete dropdown 

## Codesandbox link - with error and with fix
https://codesandbox.io/s/dazzling-morse-ybiwd7
