### PR TITLE
fix type definitions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -23,7 +23,7 @@ declare module 'react-autocomplete-input' {
       offsetY?: number;
       passThroughEnter?: boolean;
       passThroughTab?: boolean;
-    } & IntrinsicAttributes;
+    } & JSX.IntrinsicAttributes;
   
     export type AutocompleteTextFieldProps =
       | ({


### PR DESCRIPTION
This PR resolves the issue described [here](https://github.com/yury-dymov/react-autocomplete-input/issues/106#issue-1917464991).