### PR TITLE
fix: wrong suggestions list position when text field is scrolled

### DIFF
--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -385,7 +385,7 @@ class AutocompleteTextField extends React.Component {
       const caretPos = getCaretCoordinates(input, caret);
       const rect = input.getBoundingClientRect();
 
-      const top = caretPos.top + input.offsetTop;
+      const top = caretPos.top + input.offsetTop - input.scrollTop;
       const left = Math.min(
         caretPos.left + input.offsetLeft - OPTION_LIST_Y_OFFSET,
         input.offsetLeft + rect.width - OPTION_LIST_MIN_WIDTH,


### PR DESCRIPTION
When the text field is scrolled the suggestion list was calculating its position without considering the scroll offset

#### Original
![image](https://github.com/yury-dymov/react-autocomplete-input/assets/29198524/5fc51976-d480-48cd-8ab2-9587f28db921)

#### With fix
![image](https://github.com/yury-dymov/react-autocomplete-input/assets/29198524/e95e236c-e8de-4350-b5ab-99595c9aece4)
