### PR TITLE
fix: bad positioning when inside a scrolled container

### DIFF
--- a/src/AutoCompleteTextField.css
+++ b/src/AutoCompleteTextField.css
@@ -8,7 +8,7 @@
    font-size: 14px;
    list-style: none;
    padding: 1px;
-   position: absolute;
+   position: fixed;
    text-align: left;
    z-index: 20000;
 }

--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -111,6 +111,7 @@ class AutocompleteTextField extends React.Component {
 
   componentDidMount() {
     window.addEventListener('resize', this.handleResize);
+    window.addEventListener('scroll', this.handleResize);
   }
 
   componentDidUpdate(prevProps) {
@@ -124,6 +125,7 @@ class AutocompleteTextField extends React.Component {
 
   componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize);
+    window.removeEventListener('scroll', this.handleResize);
   }
 
   getMatch(str, caret, providedOptions) {
@@ -385,7 +387,7 @@ class AutocompleteTextField extends React.Component {
       const caretPos = getCaretCoordinates(input, caret);
       const rect = input.getBoundingClientRect();
 
-      const top = caretPos.top + input.offsetTop - input.scrollTop;
+      const top = caretPos.top + rect.top - input.scrollTop;
       const left = Math.min(
         caretPos.left + input.offsetLeft - OPTION_LIST_Y_OFFSET,
         input.offsetLeft + rect.width - OPTION_LIST_MIN_WIDTH,


### PR DESCRIPTION
When rendered inside a container and such container is scrolled, the dropdown menu is bad positioned, often outside the screen.

To solve it I used the bounding rect top coordinate instead of the input one and `position: fixed` instead of `absolute` for the dropdown menu

Also hidden the menu when the page scrolls since previously was rendered always in the same position despite the input was scrolling away