### PR TITLE
fix: onBlur handler called before handling onClick on item

### DIFF
--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -473,6 +473,7 @@ class AutocompleteTextField extends React.Component {
           className={idx === selection ? 'active' : null}
           key={val}
           onClick={() => { this.handleSelection(idx); }}
+          onMouseDown={(e) => { e.preventDefault(); }}
           onMouseEnter={() => { this.setState({ selection: idx }); }}
         >
           {val.slice(0, highlightStart)}


### PR DESCRIPTION
The implementation of the `onBlur` that hide the item menu was preventing the `onClick` of the item to be correctly fired and handled.
This PR adds an `onMouseDown` to the item which fires before the input `onBlur` preventing the list to be closed too soon