### PR TITLE
Scrollable options menu, and other minor additions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,9 +16,11 @@
     "jsx-a11y/no-noninteractive-element-interactions": 0,
     "class-methods-use-this": 0,
     "brace-style": "off",
-    "arrow-parens": "off"
+    "arrow-parens": "off",
+    "no-console": "off",
   },
   "globals": {
-    "window": true
+    "window": true,
+    "document": true
   }
 }

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import ReactDOM, { findDOMNode } from 'react-dom';
 import TextField from '../../src/AutoCompleteTextField';
 
-import '../dist/bundle.css';
+import '../../dist/bundle.css';
 
 class App extends Component {
   constructor() {

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -19,6 +19,7 @@ class App extends Component {
     this.handleTriggerChange = this.handleTriggerChange.bind(this);
     this.handleTriggerArrayChange = this.handleTriggerArrayChange.bind(this)
     this.handleTriggerSwitch = this.handleTriggerSwitch.bind(this)
+    this.handleIgnoreCaseChange = this.handleIgnoreCaseChange.bind(this);
 
     this.state = {
       disabled: false,
@@ -30,7 +31,8 @@ class App extends Component {
       spacer: " ",
       trigger: '@',
       triggerArray: ['@', '!!'],
-      isTriggerArray: false
+      isTriggerArray: false,
+      ignoreCase: false
     };
   }
 
@@ -81,6 +83,10 @@ class App extends Component {
     this.setState({ isTriggerArray: !this.state.isTriggerArray })
   }
 
+  handleIgnoreCaseChange() {
+    this.setState({ ignoreCase: !this.state.ignoreCase });
+  }
+
   render() {
     const options = this.state.options.sort((a, b) => a.localeCompare(b)).map(option => <li key={option}>{option}</li>);
 
@@ -101,6 +107,7 @@ class App extends Component {
             spaceRemovers={this.state.spaceRemovers}
             spacer={this.state.spacer}
             trigger={this.state.isTriggerArray ? this.state.triggerArray : this.state.trigger}
+            ignoreCase={this.state.ignoreCase}
           />
         </div>
         <hr style={{ margin: '20px 0' }} />
@@ -175,6 +182,14 @@ class App extends Component {
           <p>Default value: '^[a-zA-Z0-9\-_]+$'</p>
           <div className="field">
             <input onBlur={this.handleRegexChange} defaultValue={this.state.regex} />
+          </div>
+        </div>
+        <div className="option-block">
+          <h3>ignoreCase : boolean</h3>
+          <p>Use case-insensitive comparison of input text with trigger</p>
+          <p>Default value: false</p>
+          <div className="field">
+            <input type="checkbox" onChange={this.handleIgnoreCaseChange} checked={this.state.ignoreCase} />
           </div>
         </div>
         <div className="option-block">

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -20,6 +20,7 @@ class App extends Component {
     this.handleTriggerArrayChange = this.handleTriggerArrayChange.bind(this)
     this.handleTriggerSwitch = this.handleTriggerSwitch.bind(this)
     this.handleIgnoreCaseChange = this.handleIgnoreCaseChange.bind(this);
+    this.handleTriggerInsideWordChange = this.handleTriggerInsideWordChange.bind(this);
 
     this.state = {
       disabled: false,
@@ -32,7 +33,8 @@ class App extends Component {
       trigger: '@',
       triggerArray: ['@', '!!'],
       isTriggerArray: false,
-      ignoreCase: false
+      ignoreCase: false,
+      triggerInsideWord: true,
     };
   }
 
@@ -87,6 +89,10 @@ class App extends Component {
     this.setState({ ignoreCase: !this.state.ignoreCase });
   }
 
+  handleTriggerInsideWordChange() {
+    this.setState({ triggerInsideWord: !this.state.triggerInsideWord });
+  }
+
   render() {
     const options = this.state.options.sort((a, b) => a.localeCompare(b)).map(option => <li key={option}>{option}</li>);
 
@@ -108,6 +114,7 @@ class App extends Component {
             spacer={this.state.spacer}
             trigger={this.state.isTriggerArray ? this.state.triggerArray : this.state.trigger}
             ignoreCase={this.state.ignoreCase}
+            triggerInsideWord={this.state.triggerInsideWord}
           />
         </div>
         <hr style={{ margin: '20px 0' }} />
@@ -190,6 +197,14 @@ class App extends Component {
           <p>Default value: false</p>
           <div className="field">
             <input type="checkbox" onChange={this.handleIgnoreCaseChange} checked={this.state.ignoreCase} />
+          </div>
+        </div>
+        <div className="option-block">
+          <h3>triggerInsideWord : boolean</h3>
+          <p>Allow triggering inside word</p>
+          <p>Default value: true</p>
+          <div className="field">
+            <input type="checkbox" onChange={this.handleTriggerInsideWordChange} checked={this.state.triggerInsideWord} />
           </div>
         </div>
         <div className="option-block">

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "get-input-selection": "^1.1.4",
     "lodash.isequal": "^4.5.0",
     "prop-types": "^15.7.2",
+    "scroll-into-view-if-needed": "^3.1.0",
     "textarea-caret": "^3.0.2"
   },
   "peerDependencies": {

--- a/src/AutoCompleteTextField.css
+++ b/src/AutoCompleteTextField.css
@@ -12,6 +12,7 @@
    text-align: left;
    z-index: 20000;
    overflow-y: scroll;
+   margin-top: 1em;
 }
 
 .react-autocomplete-input > li {

--- a/src/AutoCompleteTextField.css
+++ b/src/AutoCompleteTextField.css
@@ -11,6 +11,7 @@
    position: fixed;
    text-align: left;
    z-index: 20000;
+   overflow-y: scroll;
 }
 
 .react-autocomplete-input > li {

--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -403,7 +403,7 @@ class AutocompleteTextField extends React.Component {
       const caretPos = getCaretCoordinates(input, caret);
       const rect = input.getBoundingClientRect();
 
-      const top = caretPos.top + caretPos.height + rect.top - input.scrollTop;
+      const top = caretPos.top + rect.top - input.scrollTop;
       const left = Math.min(
         /* Fully inside the viewport */
         caretPos.left + rect.left - input.scrollLeft,

--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -49,6 +49,7 @@ const propTypes = {
   passThroughEnter: PropTypes.bool,
   passThroughTab: PropTypes.bool,
   ignoreCase: PropTypes.bool,
+  triggerInsideWord: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -76,6 +77,7 @@ const defaultProps = {
   passThroughEnter: false,
   passThroughTab: true,
   ignoreCase: false,
+  triggerInsideWord: true,
 };
 
 class AutocompleteTextField extends React.Component {
@@ -235,10 +237,14 @@ class AutocompleteTextField extends React.Component {
   }
 
   isTrigger(trigger, str, i) {
-    const { ignoreCase } = this.props;
+    const { ignoreCase, triggerInsideWord } = this.props;
 
     if (!trigger || !trigger.length) {
       return true;
+    }
+
+    if (!triggerInsideWord && i > 0 && str.charAt(i - 1).match(/[\w]/)) {
+      return false;
     }
 
     if (str.substr(i, trigger.length) === trigger

--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import getCaretCoordinates from 'textarea-caret';
 import getInputSelection, { setCaretPosition } from 'get-input-selection';
 import isEqual from 'lodash.isequal';
+import scrollIntoView from 'scroll-into-view-if-needed';
 import './AutoCompleteTextField.css';
 
 const KEY_UP = 38;
@@ -12,7 +13,6 @@ const KEY_ENTER = 14;
 const KEY_ESCAPE = 27;
 const KEY_TAB = 9;
 
-const OPTION_LIST_Y_OFFSET = 10;
 const OPTION_LIST_MIN_WIDTH = 100;
 
 const propTypes = {
@@ -108,6 +108,8 @@ class AutocompleteTextField extends React.Component {
     this.recentValue = props.defaultValue;
     this.enableSpaceRemovers = false;
     this.refInput = createRef();
+    this.refCurrent = createRef();
+    this.refParent = createRef();
   }
 
   componentDidMount() {
@@ -118,9 +120,14 @@ class AutocompleteTextField extends React.Component {
   componentDidUpdate(prevProps) {
     const { options } = this.props;
     const { caret } = this.state;
+    const { helperVisible } = this.state;
 
     if (!isEqual(options, prevProps.options)) {
       this.updateHelper(this.recentValue, caret, options);
+    }
+
+    if (helperVisible && this.refCurrent.current) {
+      scrollIntoView(this.refCurrent.current, { boundary: this.refParent.current, scrollMode: 'if-needed' });
     }
   }
 
@@ -396,10 +403,12 @@ class AutocompleteTextField extends React.Component {
       const caretPos = getCaretCoordinates(input, caret);
       const rect = input.getBoundingClientRect();
 
-      const top = caretPos.top + rect.top - input.scrollTop;
+      const top = caretPos.top + caretPos.height + rect.top - input.scrollTop;
       const left = Math.min(
-        caretPos.left + input.offsetLeft - OPTION_LIST_Y_OFFSET,
-        input.offsetLeft + rect.width - OPTION_LIST_MIN_WIDTH,
+        /* Fully inside the viewport */
+        caretPos.left + rect.left - input.scrollLeft,
+        /* Ensure minimal width inside viewport */
+        window.innerWidth - OPTION_LIST_MIN_WIDTH,
       );
 
       const { minChars, onRequestOptions, requestOnlyIfNoOptions } = this.props;
@@ -471,6 +480,7 @@ class AutocompleteTextField extends React.Component {
       return (
         <li
           className={idx === selection ? 'active' : null}
+          ref={idx === selection ? this.refCurrent : null}
           key={val}
           onClick={() => { this.handleSelection(idx); }}
           onMouseDown={(e) => { e.preventDefault(); }}
@@ -483,8 +493,21 @@ class AutocompleteTextField extends React.Component {
       );
     });
 
+    /* FIXME: de-hardcode that 5 pixels margin */
+    const maxWidth = window.innerWidth - left - offsetX - 5;
+    const maxHeight = window.innerHeight - top - offsetY - 5;
+
     return (
-      <ul className="react-autocomplete-input" style={{ left: left + offsetX, top: top + offsetY }}>
+      <ul
+        className="react-autocomplete-input"
+        style={{
+          left: left + offsetX,
+          top: top + offsetY,
+          maxHeight,
+          maxWidth,
+        }}
+        ref={this.refParent}
+      >
         {helperOptions}
       </ul>
     );

--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -48,6 +48,7 @@ const propTypes = {
   offsetY: PropTypes.number,
   passThroughEnter: PropTypes.bool,
   passThroughTab: PropTypes.bool,
+  ignoreCase: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -74,6 +75,7 @@ const defaultProps = {
   value: null,
   passThroughEnter: false,
   passThroughTab: true,
+  ignoreCase: false,
 };
 
 class AutocompleteTextField extends React.Component {
@@ -233,11 +235,14 @@ class AutocompleteTextField extends React.Component {
   }
 
   isTrigger(trigger, str, i) {
+    const { ignoreCase } = this.props;
+
     if (!trigger || !trigger.length) {
       return true;
     }
 
-    if (str.substr(i, trigger.length) === trigger) {
+    if (str.substr(i, trigger.length) === trigger
+        || (ignoreCase && str.substr(i, trigger.length).toLowerCase() === trigger.toLowerCase())) {
       return true;
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,6 +1876,11 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
+compute-scroll-into-view@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz#753f11d972596558d8fe7c6bcbc8497690ab4c87"
+  integrity sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -4615,6 +4620,13 @@ schema-utils@^3.0.0, schema-utils@^3.1.0, schema-utils@^3.1.1:
     "@types/json-schema" "^7.0.8"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
+
+scroll-into-view-if-needed@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz#fa9524518c799b45a2ef6bbffb92bcad0296d01f"
+  integrity sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==
+  dependencies:
+    compute-scroll-into-view "^3.0.2"
 
 "semver@2 || 3 || 4 || 5", semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"


### PR DESCRIPTION
Make the menu scrollable if it is longer than the screen height. 
Also, improve horizontal positioning.
Also, adds an option to do case-insensitive comparison between input text and trigger.
Also, adds an option to disable triggering inside the word (so, the trigger should be at the word start only). 

Uses https://github.com/scroll-into-view/scroll-into-view-if-needed