### PR TITLE
Option to prevent triggering inside the word

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ Useful if you want to have the form submit as soon as a single value is chosen.
 If true, then an Tab keypress is passed on (after being used to autocomplete) to the next form input.
 Else, it allows users to autocomplete their input with tab and keep typing.
 
+## triggerMatchWholeWord: boolean
+#### Default value: false
+If true, do not consider the trigger when it appears as a part of longer word. E.g. if the trigger is `class=` do not show the options menu on `subclass=`. If false, any occurrence of the trigger will open the menu.
+
 # Styles Customization
 By default styles are defined in `"react-autocomplete-input/dist/bundle.css"`, however, you may define your custom styles instead for following entities:
 

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -19,6 +19,7 @@ class App extends Component {
     this.handleTriggerChange = this.handleTriggerChange.bind(this);
     this.handleTriggerArrayChange = this.handleTriggerArrayChange.bind(this)
     this.handleTriggerSwitch = this.handleTriggerSwitch.bind(this)
+    this.handleTriggerInsideWordChange = this.handleTriggerInsideWordChange.bind(this);
 
     this.state = {
       disabled: false,
@@ -30,7 +31,8 @@ class App extends Component {
       spacer: " ",
       trigger: '@',
       triggerArray: ['@', '!!'],
-      isTriggerArray: false
+      isTriggerArray: false,
+      triggerInsideWord: true,
     };
   }
 
@@ -81,6 +83,10 @@ class App extends Component {
     this.setState({ isTriggerArray: !this.state.isTriggerArray })
   }
 
+  handleTriggerInsideWordChange() {
+    this.setState({ triggerInsideWord: !this.state.triggerInsideWord });
+  }
+
   render() {
     const options = this.state.options.sort((a, b) => a.localeCompare(b)).map(option => <li key={option}>{option}</li>);
 
@@ -101,6 +107,7 @@ class App extends Component {
             spaceRemovers={this.state.spaceRemovers}
             spacer={this.state.spacer}
             trigger={this.state.isTriggerArray ? this.state.triggerArray : this.state.trigger}
+            triggerInsideWord={this.state.triggerInsideWord}
           />
         </div>
         <hr style={{ margin: '20px 0' }} />
@@ -175,6 +182,14 @@ class App extends Component {
           <p>Default value: '^[a-zA-Z0-9\-_]+$'</p>
           <div className="field">
             <input onBlur={this.handleRegexChange} defaultValue={this.state.regex} />
+          </div>
+        </div>
+        <div className="option-block">
+          <h3>triggerInsideWord : boolean</h3>
+          <p>Allow triggering inside word</p>
+          <p>Default value: true</p>
+          <div className="field">
+            <input type="checkbox" onChange={this.handleTriggerInsideWordChange} checked={this.state.triggerInsideWord} />
           </div>
         </div>
         <div className="option-block">

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -19,7 +19,7 @@ class App extends Component {
     this.handleTriggerChange = this.handleTriggerChange.bind(this);
     this.handleTriggerArrayChange = this.handleTriggerArrayChange.bind(this)
     this.handleTriggerSwitch = this.handleTriggerSwitch.bind(this)
-    this.handleTriggerInsideWordChange = this.handleTriggerInsideWordChange.bind(this);
+    this.handleTriggerMatchWholeWordChange = this.handleTriggerMatchWholeWordChange.bind(this);
 
     this.state = {
       disabled: false,
@@ -32,7 +32,7 @@ class App extends Component {
       trigger: '@',
       triggerArray: ['@', '!!'],
       isTriggerArray: false,
-      triggerInsideWord: true,
+      triggerMatchWholeWord: false,
     };
   }
 
@@ -83,8 +83,8 @@ class App extends Component {
     this.setState({ isTriggerArray: !this.state.isTriggerArray })
   }
 
-  handleTriggerInsideWordChange() {
-    this.setState({ triggerInsideWord: !this.state.triggerInsideWord });
+  handleTriggerMatchWholeWordChange() {
+    this.setState({ triggerMatchWholeWord: !this.state.triggerMatchWholeWord });
   }
 
   render() {
@@ -107,7 +107,7 @@ class App extends Component {
             spaceRemovers={this.state.spaceRemovers}
             spacer={this.state.spacer}
             trigger={this.state.isTriggerArray ? this.state.triggerArray : this.state.trigger}
-            triggerInsideWord={this.state.triggerInsideWord}
+            triggerMatchWholeWord={this.state.triggerMatchWholeWord}
           />
         </div>
         <hr style={{ margin: '20px 0' }} />
@@ -185,11 +185,11 @@ class App extends Component {
           </div>
         </div>
         <div className="option-block">
-          <h3>triggerInsideWord : boolean</h3>
-          <p>Allow triggering inside word</p>
-          <p>Default value: true</p>
+          <h3>triggerMatchWholeWord : boolean</h3>
+          <p>Only match the trigger when it is an isolated word (i.e. do not trigger on subwords)</p>
+          <p>Default value: false</p>
           <div className="field">
-            <input type="checkbox" onChange={this.handleTriggerInsideWordChange} checked={this.state.triggerInsideWord} />
+            <input type="checkbox" onChange={this.handleTriggerMatchWholeWordChange} checked={this.state.triggerMatchWholeWord} />
           </div>
         </div>
         <div className="option-block">

--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -48,6 +48,7 @@ const propTypes = {
   offsetY: PropTypes.number,
   passThroughEnter: PropTypes.bool,
   passThroughTab: PropTypes.bool,
+  triggerInsideWord: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -74,6 +75,7 @@ const defaultProps = {
   value: null,
   passThroughEnter: false,
   passThroughTab: true,
+  triggerInsideWord: true,
 };
 
 class AutocompleteTextField extends React.Component {
@@ -226,8 +228,13 @@ class AutocompleteTextField extends React.Component {
   }
 
   isTrigger(trigger, str, i) {
+    const { triggerInsideWord } = this.props;
     if (!trigger || !trigger.length) {
       return true;
+    }
+
+    if (!triggerInsideWord && i > 0 && str.charAt(i - 1).match(/[\w]/)) {
+      return false;
     }
 
     if (str.substr(i, trigger.length) === trigger) {

--- a/src/AutoCompleteTextField.js
+++ b/src/AutoCompleteTextField.js
@@ -48,7 +48,7 @@ const propTypes = {
   offsetY: PropTypes.number,
   passThroughEnter: PropTypes.bool,
   passThroughTab: PropTypes.bool,
-  triggerInsideWord: PropTypes.bool,
+  triggerMatchWholeWord: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -75,7 +75,7 @@ const defaultProps = {
   value: null,
   passThroughEnter: false,
   passThroughTab: true,
-  triggerInsideWord: true,
+  triggerMatchWholeWord: false,
 };
 
 class AutocompleteTextField extends React.Component {
@@ -228,12 +228,12 @@ class AutocompleteTextField extends React.Component {
   }
 
   isTrigger(trigger, str, i) {
-    const { triggerInsideWord } = this.props;
+    const { triggerMatchWholeWord } = this.props;
     if (!trigger || !trigger.length) {
       return true;
     }
 
-    if (!triggerInsideWord && i > 0 && str.charAt(i - 1).match(/[\w]/)) {
+    if (triggerMatchWholeWord && i > 0 && str.charAt(i - 1).match(/[\w]/)) {
       return false;
     }
 


### PR DESCRIPTION
Originally part of #123.
The feature is disabled by default. To enable, set `triggerInsideWord=false`, then it will not trigger on parts of longer words (e.g. `subclass` will not trigger the options defined for `class`)