### PR TITLE
Add missing TextArea attributes

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -23,7 +23,7 @@ declare module 'react-autocomplete-input' {
       offsetY?: number;
       passThroughEnter?: boolean;
       passThroughTab?: boolean;
-    } & JSX.IntrinsicAttributes;
+    } & JSX.IntrinsicAttributes & InputHTMLAttributes<HTMLTextAreaElement>;
   
     export type AutocompleteTextFieldProps =
       | ({


### PR DESCRIPTION
There were some attributes missing from the types. In particular placeholder, as mentioned in #124. The missing props are in the InputHTMLAttributes<HTMLTextAreaElement> interface. 
Fixes #124 